### PR TITLE
feat(profile): synchronize edit-profile changes with CRM

### DIFF
--- a/src/enums/api-route.enum.ts
+++ b/src/enums/api-route.enum.ts
@@ -9,11 +9,11 @@ const ApiRoute = {
   VERIFY_OLD_PASSWORD: '/auth/verify-password',
   CHANGE_PASSWORD: '/auth/change-password',
   UPDATE_USER: '/user/id',
+  DELETE_USER: '/user',
 
   QOBRIX_CREATE_CONTACT: '/contacts',
   QOBRIX_CREATE_AGENT: '/agents',
   QOBRIX_PROPERY_TYPES: '/property-types',
-  DELETE_USER: '/user',
 } as const;
 
 export { ApiRoute };

--- a/src/sections/user/service.ts
+++ b/src/sections/user/service.ts
@@ -10,7 +10,7 @@ export const revertFormatRole = (stateRole: string): string => {
 
 export const formatRole = (inputRole: string): string => {
   switch (inputRole) {
-    case 'independent Agent':
+    case 'Independent Agent':
       return 'individual_agent';
 
     default:

--- a/src/sections/user/user-new-edit-form.tsx
+++ b/src/sections/user/user-new-edit-form.tsx
@@ -14,7 +14,7 @@ import ReduxProvider from 'store/ReduxProvider';
 import { useRouter } from 'routes/hooks';
 import { patterns } from 'constants/patterns';
 import { AppRoute } from 'enums';
-import { IUserUpdateProfile } from 'types/user';
+import { IUserUpdateProfile, IUserUpdateQobrix } from 'types/user';
 import { fData } from 'utils/format-number';
 import { countries } from 'assets/data';
 import Iconify from 'components/iconify';
@@ -26,6 +26,7 @@ import {
   findCountryLabelByCode,
 } from 'sections/verification-view/drop-box-data';
 import { UserProfileResponse } from 'store/auth/lib/types';
+import { useUpdateContactMutation } from 'store/api/qobrixApi';
 import { formatRole, revertFormatRole } from './service';
 import ProfileSettings from './user-edit-settings';
 
@@ -41,12 +42,17 @@ function getRoles(): string[] {
 
 export default function UserNewEditForm({ user }: Props): JSX.Element {
   const router = useRouter();
+
   const [updateUser] = useUpdateUserMutation();
+  const [updateContact] = useUpdateContactMutation();
   const [setAvatar] = useSetAvatarMutation();
+
   const { enqueueSnackbar } = useSnackbar();
+
   const t = useTranslations('editProfilePage');
 
   const [selectedValue, setSelectedValue] = useState<string>('');
+
   const shouldRenderAgency = selectedValue === getRoles()[1];
 
   const {
@@ -61,6 +67,7 @@ export default function UserNewEditForm({ user }: Props): JSX.Element {
   } = user;
 
   const userId = user.id;
+  const qobrixId = user.qobrixContactId;
 
   useEffect(() => {
     if (stateRole) {
@@ -133,6 +140,14 @@ export default function UserNewEditForm({ user }: Props): JSX.Element {
     updatedUser.agencyName = agency ?? stateAgency;
     updatedUser.description = about ? about : stateDescription;
 
+    const qobrixUser: IUserUpdateQobrix = {
+      city: updatedUser.city,
+      country: updatedUser.country,
+      description: updatedUser.description,
+      phone: updatedUser.phone,
+      role: updatedUser.role,
+    };
+
     const formData = new FormData();
 
     try {
@@ -141,6 +156,8 @@ export default function UserNewEditForm({ user }: Props): JSX.Element {
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
       await updateUser(updatedUser).unwrap();
+
+      await updateContact({ qobrixId, ...qobrixUser }).unwrap();
 
       if (avatar && avatar instanceof Blob) {
         formData.append('file', avatar);

--- a/src/store/api/qobrixApi.ts
+++ b/src/store/api/qobrixApi.ts
@@ -7,6 +7,7 @@ import {
   QobrixContactResponse,
   QobrixPropertyType,
 } from 'types';
+import { IUserUpdateQobrix } from 'types/user';
 
 export const QobrixApi = createApi({
   reducerPath: 'QobrixApi',
@@ -43,8 +44,19 @@ export const QobrixApi = createApi({
         body,
       }),
     }),
+    updateContact: builder.mutation<QobrixContactResponse['data'], IUserUpdateQobrix>({
+      query: ({ qobrixId, ...body }) => ({
+        url: `${ApiRoute.QOBRIX_CREATE_CONTACT}/${qobrixId}`,
+        method: 'PATCH',
+        body,
+      }),
+    }),
   }),
 });
 
-export const { useCreateContactMutation, useCreateAgentMutation, useGetPropertyTypesQuery } =
-  QobrixApi;
+export const {
+  useCreateContactMutation,
+  useCreateAgentMutation,
+  useGetPropertyTypesQuery,
+  useUpdateContactMutation,
+} = QobrixApi;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -47,6 +47,16 @@ export type IUserUpdateProfile = {
   userId?: string | null;
   qobrixContactId?: string | null;
   description?: string | null;
+  qobrixId?: string | null;
+};
+
+export type IUserUpdateQobrix = {
+  city?: string | null;
+  country?: string | null;
+  description?: string | null;
+  phone?: string | null;
+  role?: string | null;
+  qobrixId?: string | null;
 };
 
 export type IUserProfileFollower = {


### PR DESCRIPTION
## Describe your changes

- Added synchronization of profile edits with the CRM system. Now, when a user updates his profile, the changes are reflected not only in our database but also in the CRM.

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://testhomework4.atlassian.net/jira/software/projects/AG/boards/6?selectedIssue=AG-181)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [ ] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [ ] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.


