### PR TITLE
feat(sign-in): restrict sign-in on desktop and show modal

### DIFF
--- a/src/app/[locale]/sign-in/components/modal/index.tsx
+++ b/src/app/[locale]/sign-in/components/modal/index.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { useTranslations } from 'next-intl';
+import { DialogContentText } from '@mui/material';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function DesktopDialog({ open, onClose }: Props) {
+  const t = useTranslations('signInPage');
+
+  const descriptionElementRef = React.useRef<HTMLElement>(null);
+
+  React.useEffect(() => {
+    if (open) {
+      const { current: descriptionElement } = descriptionElementRef;
+
+      if (descriptionElement !== null) {
+        descriptionElement.focus();
+      }
+    }
+  }, [open]);
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+        maxWidth="lg"
+      >
+        <DialogContent sx={{ paddingTop: '4rem' }}>
+          <DialogContentText
+            id="alert-dialog-description"
+            ref={descriptionElementRef}
+            tabIndex={-1}
+            variant="h5"
+          >
+            {t('Modal.message')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={onClose}
+            color="primary"
+            variant="contained"
+            sx={{ padding: '8px 14px' }}
+          >
+            {t('Modal.btnTxt')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/[locale]/sign-in/page.tsx
+++ b/src/app/[locale]/sign-in/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { notFound } from 'next/navigation';
+import { notFound, useRouter } from 'next/navigation';
 import Link from '@mui/material/Link';
 import { Box } from '@mui/material';
 import { Locale } from 'locales/i18n.config';
@@ -11,17 +11,22 @@ import SeoIllustration from 'assets/illustrations/seo-illustration';
 import { LoadingScreen } from 'components/loading-screen';
 import { PolicyComponent } from 'components/PolicyComponent/PolicyComponent';
 import { SnackbarProvider } from 'components/snackbar';
+import { dimensionValues } from 'constants/dimensionValues';
 import { SignInPageType, SignUpPageType } from 'types/auth';
 import LoginForm from './components/form';
 import { Wrapper, LeftSection, LoginWrapper, RightSection, SignUpLink, Policy } from './styles';
+import DesktopDialog from './components/modal';
 
 type Props = {
   params: { locale: Locale };
 };
 
 export default function SignInPage({ params: { locale } }: Props) {
+  const router = useRouter();
+
   const [data, setData] = useState<SignInPageType | null>(null);
   const [termsData, setTermsData] = useState<SignUpPageType | null>(null);
+  const [open, setOpen] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -38,39 +43,59 @@ export default function SignInPage({ params: { locale } }: Props) {
     fetchData();
   }, [locale]);
 
+  useEffect(() => {
+    const handleResize = (): void => {
+      const { innerWidth } = window;
+      setOpen(innerWidth >= dimensionValues.DESKTOP_THRESHOLD_WIDTH);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const handleClose = (): void => {
+    setOpen(false);
+    router.push(AppRoute.HOME_PAGE);
+  };
+
   if (!data || !termsData) {
     return <LoadingScreen />;
   }
 
   return (
-    <Wrapper>
-      <LeftSection>
-        <SeoIllustration maxWidth="80%" />
-      </LeftSection>
-      <RightSection>
-        <LoginWrapper>
-          <SnackbarProvider>
-            <LoginForm />
-          </SnackbarProvider>
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexDirection: 'column',
-              width: '90%',
-            }}
-          >
-            <SignUpLink>
-              {data.Main.doNot}&nbsp;
-              <Link href={AppRoute.SIGN_UP_PAGE}>{data.Main.signUpLink}</Link>
-            </SignUpLink>
-            <Policy>
-              <PolicyComponent signUpPage={termsData} />
-            </Policy>
-          </Box>
-        </LoginWrapper>
-      </RightSection>
-    </Wrapper>
+    <>
+      {open && <DesktopDialog open={open} onClose={handleClose} />}
+      <Wrapper>
+        <LeftSection>
+          <SeoIllustration maxWidth="80%" />
+        </LeftSection>
+        <RightSection>
+          <LoginWrapper>
+            <SnackbarProvider>
+              <LoginForm />
+            </SnackbarProvider>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                flexDirection: 'column',
+                width: '90%',
+              }}
+            >
+              <SignUpLink>
+                {data.Main.doNot}&nbsp;
+                <Link href={AppRoute.SIGN_UP_PAGE}>{data.Main.signUpLink}</Link>
+              </SignUpLink>
+              <Policy>
+                <PolicyComponent signUpPage={termsData} />
+              </Policy>
+            </Box>
+          </LoginWrapper>
+        </RightSection>
+      </Wrapper>
+    </>
   );
 }

--- a/src/constants/dimensionValues.ts
+++ b/src/constants/dimensionValues.ts
@@ -1,0 +1,3 @@
+export const dimensionValues = {
+  DESKTOP_THRESHOLD_WIDTH: 768,
+};

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -118,6 +118,10 @@
       "emailInvalid": "Email format is incorrect. Please enter a valid email",
       "passwordRequired": "Password is required",
       "minChar": "Password needs to be at least 8 characters"
+    },
+    "Modal": {
+      "message": "Please Sign in using your mobile device!",
+      "btnTxt": "Close"
     }
   },
   "signUpPage": {


### PR DESCRIPTION
## Describe your changes

- Added functionality to monitor the user's device when viewing the Sign-in page. **Currently, we are only monitoring device dimensions due to demonstration purposes.**
When the user views this page using a Desktop PC, a modal window with the message "Please sign in using your mobile device" opens, and the user is not allowed to sign in using the desktop.

![image](https://github.com/ZenBit-Tech/ZenBitRock_fe/assets/105170538/213380a6-0f6f-4819-9c85-05f17e39ce97)


## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://testhomework4.atlassian.net/jira/software/projects/AG/boards/6?selectedIssue=AG-185)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [x] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [ ] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.

