### PR TITLE
Feat/messages page

### DIFF
--- a/src/app/[locale]/messages/[id]/page.tsx
+++ b/src/app/[locale]/messages/[id]/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Typography } from '@mui/material';
+import { useParams } from 'next/navigation';
+
+export default function PropertyPage(): JSX.Element {
+  const { id } = useParams();
+
+  return (
+    <Typography p={20} textAlign="center" variant="h1">
+      {id}
+    </Typography>
+  );
+}

--- a/src/app/[locale]/messages/layout.tsx
+++ b/src/app/[locale]/messages/layout.tsx
@@ -1,0 +1,13 @@
+import { ProtectedRoute } from 'components/custom';
+
+export const metadata = {
+  title: 'Messages',
+};
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function MessagesLayout({ children }: Props): JSX.Element {
+  return <ProtectedRoute>{children}</ProtectedRoute>;
+}

--- a/src/app/[locale]/messages/page.tsx
+++ b/src/app/[locale]/messages/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import MessagesView from 'sections/messages-view';
+
+export default function MessagesPage(): JSX.Element {
+  return <MessagesView />;
+}

--- a/src/app/[locale]/verification/layout.tsx
+++ b/src/app/[locale]/verification/layout.tsx
@@ -8,6 +8,6 @@ type Props = {
   children: React.ReactNode;
 };
 
-export default function TestLayout({ children }: Props): JSX.Element {
+export default function VerificationLayout({ children }: Props): JSX.Element {
   return <ProtectedRoute>{children}</ProtectedRoute>;
 }

--- a/src/app/[locale]/verification/page.tsx
+++ b/src/app/[locale]/verification/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from 'hooks';
 import { VerificationDoneView, VerificationView } from 'sections';
 
-export default function Verification(): JSX.Element {
+export default function VerificationPage(): JSX.Element {
   const [verified, setVerified] = useState(false);
 
   const handleVerification = useCallback(() => {

--- a/src/enums/app-route.enum.ts
+++ b/src/enums/app-route.enum.ts
@@ -16,7 +16,7 @@ const AppRoute = {
   VERIFY_OLD_PASSWORD: 'reset-password/verify-old-password',
   RESET_PASSWORD_CHANGE_PASSWORD_PAGE: '/reset-password/change-password',
   RESET_PASSWORD_DONE_PAGE: '/reset-password',
-
+  MESSAGES_PAGE: '/messages',
   EDIT_PROFILE_PAGE: '/edit-profile',
 } as const;
 

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -494,8 +494,8 @@
     "addGroupChatButton": "Add group chat",
     "searchPlaceholder": "Enter agent name",
     "sortBy": "Sort By:",
-    "sortOptionLatest": "Latest first",
-    "sortOptionOldest": "Oldest first",
+    "sortOptionLatest": "Latest",
+    "sortOptionOldest": "Oldest",
     "sortOptionNameIncrease": "Name: A-Z",
     "sortOptionNameDecrease": "Name: Z-A"
   }

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -221,12 +221,7 @@
     "sentCode": "Verification code sent successfully",
     "codeExpired": "Code is expired",
     "emailVerified": "Email verified successfully",
-    "notValid": "Please enter the security code",
-    "ErrorMessage":"Something went wrong, please try again",
-    "sentCode":"Verification code sent successfully",
-    "codeExpired":"Code is expired",
-    "emailVerified":"Email verified successfully",
-    "notValid":"Please enter the security code"
+    "notValid": "Please enter the security code"
   },
   "yup": {
     "code_too_short": "Code must be at least 6 characters",
@@ -493,5 +488,15 @@
     "email": "Email",
     "status": "Status",
     "filtered": "Filtered for the: "
+  },
+  "MessagesPage": {
+    "pageTitle": "Messages",
+    "addGroupChatButton": "Add group chat",
+    "searchPlaceholder": "Enter agent name",
+    "sortBy": "Sort By:",
+    "sortOptionLatest": "Latest first",
+    "sortOptionOldest": "Oldest first",
+    "sortOptionNameIncrease": "Name: A-Z",
+    "sortOptionNameDecrease": "Name: Z-A"
   }
 }

--- a/src/sections/messages-view/add-group-chat-button.tsx
+++ b/src/sections/messages-view/add-group-chat-button.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@mui/material';
+import Iconify from 'components/iconify';
+
+type Props = {
+  t: Function;
+};
+
+export default function AddGroupChatButton({ t }: Props): JSX.Element {
+  return (
+    <Button
+      title={t('addGroupChatButton')}
+      sx={{ padding: '14px' }}
+      variant="contained"
+      color="primary"
+    >
+      <Iconify icon="subway:add" height="auto" />
+    </Button>
+  );
+}

--- a/src/sections/messages-view/chat-item.tsx
+++ b/src/sections/messages-view/chat-item.tsx
@@ -1,0 +1,58 @@
+import {
+  Card,
+  Avatar,
+  ListItemText,
+  Stack,
+  Typography,
+  Badge,
+  CardActionArea,
+} from '@mui/material';
+import MailIcon from '@mui/icons-material/Mail';
+import { IChatItem } from 'types/chat';
+import { formatDate, trimString } from 'services';
+
+type FollowerItemProps = {
+  chat: IChatItem;
+};
+
+const MAX_WORDS: number = 6;
+
+export default function ChatItem({ chat }: FollowerItemProps): JSX.Element {
+  const { type, chatName, members, lastMessage, lastMessageDate, countOfUnreadMessages } = chat;
+
+  const messageDate = formatDate(lastMessageDate);
+
+  const avatarUrl = type === 'private' ? members[0].avatarUrl : '/';
+
+  const handleClick = () => {};
+
+  return (
+    <CardActionArea sx={{ p: 0 }} onClick={handleClick}>
+      <Card
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          width: '100%',
+          p: (theme) => theme.spacing(2, 1, 2, 1),
+        }}
+      >
+        <Avatar alt={chatName} src={avatarUrl} sx={{ width: 68, height: 68, mr: 2 }} />
+
+        <Stack sx={{ flex: 5 }}>
+          <Typography variant="subtitle1" sx={{ textAlign: 'left' }}>
+            {chatName}
+          </Typography>
+          <ListItemText secondary={trimString(lastMessage, MAX_WORDS)} sx={{ textAlign: 'left' }} />
+        </Stack>
+
+        <Stack alignItems="center" sx={{ gap: '10px', minWidth: '65px', alignItems: 'center' }}>
+          <Badge badgeContent={countOfUnreadMessages} color="primary">
+            <MailIcon />
+          </Badge>
+
+          <Typography variant="body2">{messageDate}</Typography>
+        </Stack>
+      </Card>
+    </CardActionArea>
+  );
+}

--- a/src/sections/messages-view/chat-item.tsx
+++ b/src/sections/messages-view/chat-item.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/navigation';
 import {
   Card,
   Avatar,
@@ -10,6 +11,7 @@ import {
 import MailIcon from '@mui/icons-material/Mail';
 import { IChatItem } from 'types/chat';
 import { formatDate, trimString } from 'services';
+import { AppRoute } from 'enums';
 
 type FollowerItemProps = {
   chat: IChatItem;
@@ -18,13 +20,16 @@ type FollowerItemProps = {
 const MAX_WORDS: number = 6;
 
 export default function ChatItem({ chat }: FollowerItemProps): JSX.Element {
-  const { type, chatName, members, lastMessage, lastMessageDate, countOfUnreadMessages } = chat;
+  const router = useRouter();
+  const { id, type, chatName, members, lastMessage, lastMessageDate, countOfUnreadMessages } = chat;
 
   const messageDate = formatDate(lastMessageDate);
 
   const avatarUrl = type === 'private' ? members[0].avatarUrl : '/';
 
-  const handleClick = () => {};
+  const handleClick = () => {
+    router.push(`${AppRoute.MESSAGES_PAGE}/${id}`);
+  };
 
   return (
     <CardActionArea sx={{ p: 0 }} onClick={handleClick}>

--- a/src/sections/messages-view/chats-list.tsx
+++ b/src/sections/messages-view/chats-list.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+import { Box, Stack, TextField, InputAdornment } from '@mui/material';
+import { IChatItem } from 'types/chat';
+import Iconify from 'components/iconify';
+import SearchNotFound from 'components/search-not-found';
+import AddGroupChatButton from './add-group-chat-button';
+import ChatItem from './chat-item';
+import SortComponent, { sortChats } from './sort-component';
+import { Values, getSortOptions } from './drop-box-data';
+
+type Props = {
+  chats: IChatItem[];
+  t: Function;
+};
+
+export default function ChatsList({ chats, t }: Props) {
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [sortBy, setSortBy] = useState<Values>(getSortOptions(t)[0]);
+
+  const handleSearchChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  }, []);
+
+  const filteredChats = chats.filter(
+    (chat) =>
+      chat.chatName?.toLowerCase().startsWith(searchTerm.toLowerCase()) ||
+      chat.members.some(
+        (member) =>
+          member.firstName.toLowerCase().startsWith(searchTerm.toLowerCase()) ||
+          member.lastName.toLowerCase().startsWith(searchTerm.toLowerCase())
+      )
+  );
+
+  const sortedChats = sortChats(filteredChats, sortBy.value);
+
+  const handleSortBy = useCallback((newValue: Values) => {
+    setSortBy(newValue);
+  }, []);
+
+  return (
+    <Box gap={1} display="flex" flexDirection="column">
+      <Stack
+        sx={{
+          mb: 2,
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <TextField
+          value={searchTerm}
+          onChange={handleSearchChange}
+          placeholder={t('searchPlaceholder')}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Iconify icon="eva:search-fill" sx={{ color: 'text.disabled' }} />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ flex: 1, mr: 2 }}
+        />
+
+        <AddGroupChatButton t={t} />
+      </Stack>
+
+      <SortComponent t={t} sort={sortBy} onSort={handleSortBy} sortOptions={getSortOptions(t)} />
+
+      {sortedChats.length ? (
+        sortedChats.map((chat) => <ChatItem key={chat.id} chat={chat} />)
+      ) : (
+        <SearchNotFound
+          query={searchTerm}
+          sx={{
+            p: 3,
+            mx: 'auto',
+            width: '100%',
+            bgcolor: 'background.neutral',
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/src/sections/messages-view/chats-list.tsx
+++ b/src/sections/messages-view/chats-list.tsx
@@ -38,7 +38,7 @@ export default function ChatsList({ chats, t }: Props) {
   }, []);
 
   return (
-    <Box gap={1} display="flex" flexDirection="column">
+    <Box display="flex" flexDirection="column">
       <Stack
         sx={{
           mb: 2,

--- a/src/sections/messages-view/drop-box-data.ts
+++ b/src/sections/messages-view/drop-box-data.ts
@@ -1,0 +1,13 @@
+export type Values = {
+  value: string;
+  label: string;
+};
+
+export function getSortOptions(t: Function): Array<Values> {
+  return [
+    { value: 'latest', label: t('sortOptionLatest') },
+    { value: 'oldest', label: t('sortOptionOldest') },
+    { value: 'nameIncrease', label: t('sortOptionNameIncrease') },
+    { value: 'nameDecrease', label: t('sortOptionNameDecrease') },
+  ];
+}

--- a/src/sections/messages-view/index.tsx
+++ b/src/sections/messages-view/index.tsx
@@ -1,0 +1,87 @@
+import { Typography, Container } from '@mui/material';
+import { useTranslations } from 'next-intl';
+import ChatsList from './chats-list';
+
+export default function MessagesView(): JSX.Element {
+  const t = useTranslations('MessagesPage');
+
+  const CHATS_EXAMPLE = [
+    {
+      id: '1',
+      type: 'private',
+      chatName: 'Homer Simpson',
+      members: [
+        {
+          firstName: 'Homer',
+          lastName: 'Simpson',
+          avatarUrl:
+            'https://res.cloudinary.com/dwp6n7qqj/image/upload/v1703438084/ZenBitRock/g6m2s1wn1roibzbbjddc.jpg',
+        },
+      ],
+      lastMessage: 'Ok, see you later bro!',
+      lastMessageDate: '2023-12-24 18:14:44',
+      countOfUnreadMessages: 200,
+    },
+    {
+      id: '2',
+      type: 'group',
+      chatName: 'Agents chat',
+      members: [
+        {
+          firstName: 'Homer',
+          lastName: 'Simpson',
+          avatarUrl:
+            'https://res.cloudinary.com/dwp6n7qqj/image/upload/v1703438084/ZenBitRock/g6m2s1wn1roibzbbjddc.jpg',
+        },
+        {
+          firstName: 'Marge',
+          lastName: 'Simpson',
+          avatarUrl:
+            'https://res.cloudinary.com/dwp6n7qqj/image/upload/v1703438084/ZenBitRock/g6m2s1wn1roibzbbjddc.jpg',
+        },
+      ],
+      lastMessage:
+        'Amidst the lush good greenery and serene landscapes, nature unfolds its beauty, revealing a symphony of colors, fragrances, and life, captivating hearts with its timeless charm.',
+      lastMessageDate: '2023-12-23 08:14:44',
+      countOfUnreadMessages: 10,
+    },
+    {
+      id: '3',
+      type: 'group',
+      chatName: 'Home chat',
+      members: [
+        {
+          firstName: 'Homer',
+          lastName: 'Simpson',
+          avatarUrl:
+            'https://res.cloudinary.com/dwp6n7qqj/image/upload/v1703438084/ZenBitRock/g6m2s1wn1roibzbbjddc.jpg',
+        },
+        {
+          firstName: 'Marge',
+          lastName: 'Simpson',
+          avatarUrl:
+            'https://res.cloudinary.com/dwp6n7qqj/image/upload/v1703438084/ZenBitRock/g6m2s1wn1roibzbbjddc.jpg',
+        },
+        {
+          firstName: 'Bart',
+          lastName: 'Simpson',
+          avatarUrl:
+            'https://res.cloudinary.com/dwp6n7qqj/image/upload/v1703438084/ZenBitRock/g6m2s1wn1roibzbbjddc.jpg',
+        },
+      ],
+      lastMessage:
+        'Amidst the lush good greenery and serene landscapes, nature unfolds its beauty, revealing a symphony of colors, fragrances, and life, captivating hearts with its timeless charm.',
+      lastMessageDate: '2023-12-01 11:14:44',
+      countOfUnreadMessages: 0,
+    },
+  ];
+
+  return (
+    <Container sx={{ py: 5, px: 2 }}>
+      <Typography variant="h3" sx={{ mb: '20px' }}>
+        {t('pageTitle')}
+      </Typography>
+      <ChatsList chats={CHATS_EXAMPLE} t={t} />
+    </Container>
+  );
+}

--- a/src/sections/messages-view/sort-component.tsx
+++ b/src/sections/messages-view/sort-component.tsx
@@ -1,0 +1,70 @@
+import { Box, Button, MenuItem } from '@mui/material';
+import Iconify from 'components/iconify';
+import CustomPopover, { usePopover } from 'components/custom-popover';
+import { IChatItem } from 'types/chat';
+import { Values } from './drop-box-data';
+
+type Props = {
+  t: Function;
+  sort: Values;
+  onSort: (newValue: Values) => void;
+  sortOptions: Values[];
+};
+
+export default function SortComponent({ t, sort, sortOptions, onSort }: Props): JSX.Element {
+  const popover = usePopover();
+
+  return (
+    <Box textAlign="left">
+      <Button
+        disableRipple
+        color="inherit"
+        onClick={popover.onOpen}
+        endIcon={
+          <Iconify
+            icon={popover.open ? 'eva:arrow-ios-upward-fill' : 'eva:arrow-ios-downward-fill'}
+          />
+        }
+        sx={{ fontWeight: 'fontWeightSemiBold', textTransform: 'capitalize' }}
+      >
+        {t('sortBy')}
+
+        <Box component="span" sx={{ ml: 0.5, fontWeight: 'fontWeightBold' }}>
+          {sort.label}
+        </Box>
+      </Button>
+
+      <CustomPopover open={popover.open} onClose={popover.onClose} sx={{ width: 140 }}>
+        {sortOptions.map((option) => (
+          <MenuItem
+            key={option.value}
+            selected={sort.value === option.value}
+            onClick={() => {
+              popover.onClose();
+              onSort(option);
+            }}
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </CustomPopover>
+    </Box>
+  );
+}
+
+export const sortChats = (chatsToSort: IChatItem[], sortByValue: string): IChatItem[] =>
+  [...chatsToSort].sort((a, b) => {
+    switch (sortByValue) {
+      case 'oldest':
+        return new Date(a.lastMessageDate).getTime() - new Date(b.lastMessageDate).getTime();
+
+      case 'nameIncrease':
+        return a.chatName.localeCompare(b.chatName);
+
+      case 'nameDecrease':
+        return b.chatName.localeCompare(a.chatName);
+
+      default:
+        return new Date(b.lastMessageDate).getTime() - new Date(a.lastMessageDate).getTime();
+    }
+  });

--- a/src/services/format-date-helper.ts
+++ b/src/services/format-date-helper.ts
@@ -4,7 +4,7 @@ const MONTH_INDEX_OFFSET: number = 1;
 const YEAR_SLICE_START: number = -2;
 const SHORT_DAYS_OF_WEEK: Array<string> = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-export default function formatDate(dateTimeString: string): string {
+export function formatDate(dateTimeString: string): string {
   const targetDate = new Date(dateTimeString);
   const currentDate = new Date();
   const addLeadingZero = (num: number) => (num < DOUBLE_DIGIT_THRESHOLD ? `0${num}` : num);

--- a/src/services/format-date-helper.ts
+++ b/src/services/format-date-helper.ts
@@ -1,0 +1,41 @@
+const DOUBLE_DIGIT_THRESHOLD: number = 10;
+const DAYS_IN_WEEK: number = 7;
+const MONTH_INDEX_OFFSET: number = 1;
+const YEAR_SLICE_START: number = -2;
+const SHORT_DAYS_OF_WEEK: Array<string> = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+export default function formatDate(dateTimeString: string): string {
+  const targetDate = new Date(dateTimeString);
+  const currentDate = new Date();
+  const addLeadingZero = (num: number) => (num < DOUBLE_DIGIT_THRESHOLD ? `0${num}` : num);
+
+  if (isSameDay(currentDate, targetDate)) {
+    return `${addLeadingZero(targetDate.getHours())}:${addLeadingZero(targetDate.getMinutes())}`;
+  }
+
+  if (isWithinLastWeek(currentDate, targetDate)) {
+    const dayOfWeek = SHORT_DAYS_OF_WEEK[targetDate.getDay()];
+
+    return `${dayOfWeek} ${addLeadingZero(targetDate.getHours())}:${addLeadingZero(
+      targetDate.getMinutes()
+    )}`;
+  }
+
+  const day = addLeadingZero(targetDate.getDate());
+  const month = addLeadingZero(targetDate.getMonth() + MONTH_INDEX_OFFSET);
+  const year = targetDate.getFullYear().toString().slice(YEAR_SLICE_START);
+
+  return `${day}/${month}/${year}`;
+}
+
+function isSameDay(currentDate: Date, targetDate: Date): boolean {
+  return currentDate.toDateString() === targetDate.toDateString();
+}
+
+function isWithinLastWeek(currentDate: Date, targetDate: Date): boolean {
+  const today = new Date(currentDate);
+
+  today.setDate(today.getDate() - DAYS_IN_WEEK);
+
+  return targetDate >= today;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,3 @@
+export { formatDate } from './format-date-helper';
+export { trimString } from './trim-string-helper';
+export { isFetchBaseQueryError, isErrorWithMessage } from './rtq-helper';

--- a/src/services/trim-string-helper.ts
+++ b/src/services/trim-string-helper.ts
@@ -1,4 +1,4 @@
-export default function trimString(message: string, maxWords: number) {
+export function trimString(message: string, maxWords: number) {
   const words = message.split(' ');
 
   if (words.length > maxWords) {

--- a/src/services/trim-string-helper.ts
+++ b/src/services/trim-string-helper.ts
@@ -1,0 +1,9 @@
+export default function trimString(message: string, maxWords: number) {
+  const words = message.split(' ');
+
+  if (words.length > maxWords) {
+    return `${words.slice(0, maxWords).join(' ')}...`;
+  }
+
+  return message;
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,4 +1,16 @@
-// ----------------------------------------------------------------------
+export type IChatItem = {
+  id: string;
+  type: string;
+  chatName: string;
+  members: {
+    firstName: string;
+    lastName: string;
+    avatarUrl: string;
+  }[];
+  lastMessage: string;
+  lastMessageDate: string;
+  countOfUnreadMessages: number;
+};
 
 export type IChatAttachment = {
   name: string;


### PR DESCRIPTION
## Describe your changes

- I have added messages pages and the basis for the chat page by ID. To demonstrate the rendering of chats, I added an array with fake chats, in the future, data received from the server will be used instead.
- There is a search by chat name and by the name of chat participants. You can also filter the list of chats alphabetically and by date of last message.

<img width="294" alt="image" src="https://github.com/ZenBit-Tech/ZenBitRock_fe/assets/76035623/72d5733f-3335-40d8-9973-e143e682d0b8">
<img width="294" alt="image" src="https://github.com/ZenBit-Tech/ZenBitRock_fe/assets/76035623/0741d6a3-066d-45ec-a159-3e854efd7361">

## Issue ticket code (and/or) and link

- [Link to JIRA ticket](https://testhomework4.atlassian.net/jira/software/projects/AG/boards/6?assignee=5fd26b3708757f006e4d61d4&selectedIssue=AG-213)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [x] Used the try/catch pattern for error handling
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [x] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [x] Used camelCase for variables and functions
- [x] Date and time formats are on the constants
- [x] Functions are public only if it's used outside the class
- [ ] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [ ] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.
