### PR TITLE
feat(filter): add price formatting

### DIFF
--- a/src/app/[locale]/main-page/lib/components/filter-list/filter-list.tsx
+++ b/src/app/[locale]/main-page/lib/components/filter-list/filter-list.tsx
@@ -3,7 +3,11 @@ import LoadingButton from '@mui/lab/LoadingButton';
 import { Box, Stack } from '@mui/material';
 import { useEffect, useForm, useLocalStorage, useState, useTranslations } from 'hooks';
 import { removeStorage, setStorage } from 'hooks/use-local-storage';
-import FormProvider, { RHFAutocomplete, RHFRadioGroup, RHFTextField } from 'components/hook-form';
+import FormProvider, {
+  RHFAutocomplete,
+  RHFRadioGroup,
+  RHFNumFormattedField,
+} from 'components/hook-form';
 import { Block } from 'components/custom';
 import { useGetPropertyTypesQuery, useSearchLocationsQuery } from 'store/api/qobrixApi';
 import { getLocationOptions, getMainPagePropertyFilter } from 'utils';
@@ -199,7 +203,7 @@ const FilterList = ({ applyFilters, setFilterString }: Props): JSX.Element => {
           <Block label={t('priceRange')} key={watchAllFields.rentOrSale}>
             {watchAllFields.rentOrSale === 'for_rent' ? (
               <Block sx={{ display: 'flex', flexDirection: 'row' }}>
-                <RHFTextField
+                <RHFNumFormattedField
                   name="priceRangeRentFrom"
                   type="number"
                   size="small"
@@ -207,7 +211,7 @@ const FilterList = ({ applyFilters, setFilterString }: Props): JSX.Element => {
                   sx={{ height: '60px', mr: '50px' }}
                 />
 
-                <RHFTextField
+                <RHFNumFormattedField
                   name="priceRangeRentTo"
                   type="number"
                   size="small"
@@ -217,7 +221,7 @@ const FilterList = ({ applyFilters, setFilterString }: Props): JSX.Element => {
               </Block>
             ) : (
               <Block sx={{ display: 'flex', flexDirection: 'row', gap: '0' }}>
-                <RHFTextField
+                <RHFNumFormattedField
                   name="priceRangeSaleFrom"
                   type="number"
                   size="small"
@@ -225,7 +229,7 @@ const FilterList = ({ applyFilters, setFilterString }: Props): JSX.Element => {
                   sx={{ height: '60px', mr: '50px' }}
                 />
 
-                <RHFTextField
+                <RHFNumFormattedField
                   name="priceRangeSaleTo"
                   type="number"
                   size="small"

--- a/src/app/[locale]/main-page/lib/components/filter-list/lib/validation-schema.ts
+++ b/src/app/[locale]/main-page/lib/components/filter-list/lib/validation-schema.ts
@@ -18,9 +18,11 @@ const FilterSchema = Yup.object().shape({
     .shape({ label: Yup.string().required(), value: Yup.string().required() })
     .nullable(),
   priceRangeRentFrom: Yup.number()
+    .transform((value, originalValue) => (originalValue === '' ? 0 : value))
     .min(100, 'Min 100')
     .lessThan(Yup.ref('priceRangeRentTo'), 'Should be less than max value'),
   priceRangeRentTo: Yup.number()
+    .transform((value, originalValue) => (originalValue === '' ? 0 : value))
     .min(100, 'Min 100')
     .max(10000, 'Max 10000')
     .moreThan(Yup.ref('priceRangeRentFrom'), 'Should be more than min value'),

--- a/src/components/hook-form/index.ts
+++ b/src/components/hook-form/index.ts
@@ -9,5 +9,6 @@ export { default as RHFSlider } from './rhf-slider';
 export { default as RHFTextField } from './rhf-text-field';
 export { default as RHFRadioGroup } from './rhf-radio-group';
 export { default as RHFAutocomplete } from './rhf-autocomplete';
+export { default as RHFNumFormattedField } from './rhf-num-formatted-field';
 
 export { default } from './form-provider';

--- a/src/components/hook-form/rhf-num-formatted-field.tsx
+++ b/src/components/hook-form/rhf-num-formatted-field.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { useFormContext, Controller } from 'react-hook-form';
+import TextField, { TextFieldProps } from '@mui/material/TextField';
+import { fieldFormats } from 'constants/fieldFormats';
+
+type Props = TextFieldProps & {
+  name: string;
+};
+
+export default function RHFNumFormattedField({
+  name,
+  helperText,
+  type,
+  ...other
+}: Props): JSX.Element {
+  const { control, setValue, getValues } = useFormContext();
+
+  const [inputValue, setInputValue] = useState<string>('');
+  const [formattedValue, setFormattedValue] = useState<string>('');
+
+  const formatNumber = (value: string): string => {
+    if (!value && value !== '0') return '';
+    return Number(value).toLocaleString(fieldFormats.FORMAT_ZONE);
+  };
+
+  useEffect(() => {
+    const fieldValue = getValues(name);
+    setFormattedValue(type === fieldFormats.NUMBER ? formatNumber(fieldValue) : fieldValue);
+  }, [getValues, name, type]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const value = event.target.value;
+    if (type === fieldFormats.NUMBER) {
+      if (value.trim() === '') {
+        setInputValue('');
+        setFormattedValue('');
+        setValue(name, 0, { shouldValidate: true });
+      } else {
+        const numericValue = value.replace(/[^0-9]/g, '');
+        setInputValue(numericValue);
+        setFormattedValue(formatNumber(numericValue));
+        setValue(name, numericValue, { shouldValidate: true });
+      }
+    } else {
+      setValue(name, value, { shouldValidate: true });
+    }
+  };
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field, fieldState: { error } }) => (
+        <TextField
+          {...field}
+          fullWidth
+          type="text"
+          value={type === fieldFormats.NUMBER ? formattedValue : inputValue}
+          onChange={handleChange}
+          error={!!error}
+          helperText={error ? error?.message : helperText}
+          {...other}
+        />
+      )}
+    />
+  );
+}

--- a/src/constants/fieldFormats.ts
+++ b/src/constants/fieldFormats.ts
@@ -1,0 +1,4 @@
+export const fieldFormats = {
+  FORMAT_ZONE: 'en-US',
+  NUMBER: 'number',
+};

--- a/src/utils/property-filters/getFilterString.ts
+++ b/src/utils/property-filters/getFilterString.ts
@@ -1,6 +1,7 @@
 import { PropertyFilterFormData } from 'types';
 import { QobrixPropertySaleRent } from 'enums/qobrix';
 import { randomValues } from 'constants/randomValues';
+import { fieldFormats } from 'constants/fieldFormats';
 
 const formatSlash = (value: string) => {
   const words = value.toLowerCase().split('_');
@@ -55,16 +56,32 @@ const getFilterString = (formData: PropertyFilterFormData): string => {
     filters.push(`${randomValues.BEDROOMS}: ${bedrooms.value}`);
   }
   if (rentOrSale === QobrixPropertySaleRent.FOR_SALE && priceRangeSaleFrom) {
-    filters.push(`${randomValues.PRICE_FROM}: ${priceRangeSaleFrom}`);
+    filters.push(
+      `${randomValues.PRICE_FROM}: ${Number(priceRangeSaleFrom).toLocaleString(
+        fieldFormats.FORMAT_ZONE
+      )}`
+    );
   }
   if (rentOrSale === QobrixPropertySaleRent.FOR_SALE && priceRangeSaleTo) {
-    filters.push(`${randomValues.PRICE_TO}: ${priceRangeSaleTo}`);
+    filters.push(
+      `${randomValues.PRICE_TO}: ${Number(priceRangeSaleTo).toLocaleString(
+        fieldFormats.FORMAT_ZONE
+      )}`
+    );
   }
   if (rentOrSale === QobrixPropertySaleRent.FOR_RENT && priceRangeRentFrom) {
-    filters.push(`${randomValues.PRICE_FROM}: ${priceRangeRentFrom}`);
+    filters.push(
+      `${randomValues.PRICE_FROM}: ${Number(priceRangeRentFrom).toLocaleString(
+        fieldFormats.FORMAT_ZONE
+      )}`
+    );
   }
   if (rentOrSale === QobrixPropertySaleRent.FOR_RENT && priceRangeRentTo) {
-    filters.push(`${randomValues.PRICE_TO}: ${priceRangeRentTo}`);
+    filters.push(
+      `${randomValues.PRICE_TO}: ${Number(priceRangeRentTo).toLocaleString(
+        fieldFormats.FORMAT_ZONE
+      )}`
+    );
   }
 
   return filters.join(', ');


### PR DESCRIPTION
## Describe your changes

-I added price formatting for the filter string and for the price range fields inside property filter

![image](https://github.com/ZenBit-Tech/ZenBitRock_fe/assets/105170538/c7c525a4-e944-4cfe-80fe-3f05e53ac779)
![Знімок екрана 2024-01-31 223744](https://github.com/ZenBit-Tech/ZenBitRock_fe/assets/105170538/32d9b952-a41c-42a2-8290-ff80d17eaf65)


## Issue ticket code (and/or) and link

- [Link to JIRA ticket](#https://ticket-url)

### **General**

- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Types for input and output parameters
- [x] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [ ] Don't have magic numbers
- [ ] Compare only with constants not with strings
- [ ] No ternary operator inside the ternary operator
- [x] Don't have commented code
- [ ] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [ ] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions are public only if it's used outside the class
- [ ] No hardcoded values
- [ ] covered by tests
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend

- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [ ] No inline styles
- [ ] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.


